### PR TITLE
Remove dependency to sparksuite/simplemde-markdown-editor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,21 +12,9 @@
     "SimpleMDE"
   ],
   "repositories": [
-    {
-      "type": "package",
-      "package": {
-        "name": "sparksuite/simplemde-markdown-editor",
-        "version": "1.11.2",
-        "type": "drupal-library",
-        "dist": {
-          "url": "https://github.com/sparksuite/simplemde-markdown-editor/archive/1.11.2.zip",
-          "type": "zip"
-        }
-      }
-    }
+    
   ],
   "require": {
-    "sparksuite/simplemde-markdown-editor": "1.11.2"
   },
   "require-dev": {
     "drupal/coder": "8.2.12",


### PR DESCRIPTION
`sparksuite/simplemde-markdown-editor` is not a composer package, it's an npm package. So it can't  be required using composer. 
This js library should be imported manually or using npm separatly.